### PR TITLE
feat: Enable warnings as errors for all projects

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,22 @@
+<Project>
+  <PropertyGroup>
+    <!-- Treat warnings as errors -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    
+    <!-- Enable nullable reference types -->
+    <Nullable>enable</Nullable>
+    
+    <!-- Set language version to latest -->
+    <LangVersion>latest</LangVersion>
+    
+    <!-- Enable implicit usings -->
+    <ImplicitUsings>enable</ImplicitUsings>
+    
+    <!-- Generate documentation file for all projects -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    
+    <!-- Suppress warning CS1591: Missing XML comment for publicly visible type or member -->
+    <!-- We'll suppress this for now to avoid having to document everything immediately -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/src/Zapper.API/Endpoints/Activities/ExecuteActivityEndpoint.cs
+++ b/src/Zapper.API/Endpoints/Activities/ExecuteActivityEndpoint.cs
@@ -21,16 +21,16 @@ public class ExecuteActivityEndpoint(IActivityService activityService) : Endpoin
         var success = await activityService.ExecuteActivityAsync(req.Id, ct);
         if (!success)
         {
-            await SendAsync(new ExecuteActivityResponse 
-            { 
-                Message = $"Failed to execute activity {req.Id}" 
+            await SendAsync(new ExecuteActivityResponse
+            {
+                Message = $"Failed to execute activity {req.Id}"
             }, 400, ct);
             return;
         }
 
-        await SendOkAsync(new ExecuteActivityResponse 
-        { 
-            Message = "Activity executed successfully" 
+        await SendOkAsync(new ExecuteActivityResponse
+        {
+            Message = "Activity executed successfully"
         }, ct);
     }
 }

--- a/src/Zapper.API/Endpoints/Devices/BluetoothControlEndpoint.cs
+++ b/src/Zapper.API/Endpoints/Devices/BluetoothControlEndpoint.cs
@@ -80,7 +80,7 @@ public class BluetoothControlEndpoint(IBluetoothHidController bluetoothControlle
 
     private async Task<bool> HandleSendKey(BluetoothControlRequest req, CancellationToken ct)
     {
-        if (string.IsNullOrEmpty(req.DeviceId) || string.IsNullOrEmpty(req.KeyCode) || 
+        if (string.IsNullOrEmpty(req.DeviceId) || string.IsNullOrEmpty(req.KeyCode) ||
             !Enum.TryParse<HidKeyCode>(req.KeyCode, true, out var keyCode))
         {
             return false;

--- a/src/Zapper.API/Endpoints/Devices/BluetoothDiscoveryEndpoint.cs
+++ b/src/Zapper.API/Endpoints/Devices/BluetoothDiscoveryEndpoint.cs
@@ -22,7 +22,7 @@ public class BluetoothDiscoveryEndpoint(
     {
         var androidDevices = await androidTvController.DiscoverPairedDevicesAsync(ct);
         var appleDevices = await appleTvController.DiscoverPairedDevicesAsync(ct);
-        
+
         var allDevices = androidDevices.Concat(appleDevices).Distinct();
         await SendOkAsync(allDevices, ct);
     }

--- a/src/Zapper.API/Endpoints/Devices/CreateDeviceEndpoint.cs
+++ b/src/Zapper.API/Endpoints/Devices/CreateDeviceEndpoint.cs
@@ -35,7 +35,7 @@ public class CreateDeviceEndpoint(IDeviceService deviceService) : Endpoint<Creat
         };
 
         var createdDevice = await deviceService.CreateDeviceAsync(device);
-        
+
         var response = new CreateDeviceResponse
         {
             Id = createdDevice.Id,

--- a/src/Zapper.API/Endpoints/Devices/SendCommandEndpoint.cs
+++ b/src/Zapper.API/Endpoints/Devices/SendCommandEndpoint.cs
@@ -21,16 +21,16 @@ public class SendCommandEndpoint(IDeviceService deviceService) : Endpoint<SendCo
         var success = await deviceService.SendCommandAsync(req.Id, req.CommandName, ct);
         if (!success)
         {
-            await SendAsync(new SendCommandResponse 
-            { 
-                Message = $"Failed to send command '{req.CommandName}' to device {req.Id}" 
+            await SendAsync(new SendCommandResponse
+            {
+                Message = $"Failed to send command '{req.CommandName}' to device {req.Id}"
             }, 400, ct);
             return;
         }
 
-        await SendOkAsync(new SendCommandResponse 
-        { 
-            Message = $"Command '{req.CommandName}' sent successfully" 
+        await SendOkAsync(new SendCommandResponse
+        {
+            Message = $"Command '{req.CommandName}' sent successfully"
         }, ct);
     }
 }

--- a/src/Zapper.API/Endpoints/Devices/WebOSScanEndpoint.cs
+++ b/src/Zapper.API/Endpoints/Devices/WebOSScanEndpoint.cs
@@ -45,7 +45,7 @@ public class WebOSScanEndpoint(
                 try
                 {
                     var devices = await webOsDiscovery.DiscoverDevicesAsync(TimeSpan.FromSeconds(req.DurationSeconds), ct);
-                    
+
                     foreach (var device in devices)
                     {
                         // Send real-time device discovery updates via SignalR

--- a/src/Zapper.API/Endpoints/IRCodes/ExportIRCodeSetEndpoint.cs
+++ b/src/Zapper.API/Endpoints/IRCodes/ExportIRCodeSetEndpoint.cs
@@ -17,10 +17,10 @@ public class ExportIrCodeSetEndpoint(IIrCodeService irCodeService) : Endpoint<Ex
         try
         {
             var json = await irCodeService.ExportCodeSetAsync(req.Id);
-            
+
             HttpContext.Response.ContentType = "application/json";
             HttpContext.Response.Headers["Content-Disposition"] = $"attachment; filename=\"ir-codes-{req.Id}.json\"";
-            
+
             await SendStringAsync(json, cancellation: ct);
         }
         catch (ArgumentException ex)

--- a/src/Zapper.API/Endpoints/IRCodes/GetIRCodeEndpoint.cs
+++ b/src/Zapper.API/Endpoints/IRCodes/GetIRCodeEndpoint.cs
@@ -21,7 +21,7 @@ public class GetIrCodeEndpoint(IIrCodeService irCodeService) : Endpoint<GetIrCod
             await SendNotFoundAsync(ct);
             return;
         }
-        
+
         await SendOkAsync(code, ct);
     }
 }

--- a/src/Zapper.API/Endpoints/IRCodes/GetIRCodeSetEndpoint.cs
+++ b/src/Zapper.API/Endpoints/IRCodes/GetIRCodeSetEndpoint.cs
@@ -21,7 +21,7 @@ public class GetIrCodeSetEndpoint(IIrCodeService irCodeService) : Endpoint<GetIr
             await SendNotFoundAsync(ct);
             return;
         }
-        
+
         await SendOkAsync(codeSet, ct);
     }
 }

--- a/src/Zapper.Client.Abstractions/IDeviceClient.cs
+++ b/src/Zapper.Client.Abstractions/IDeviceClient.cs
@@ -11,42 +11,42 @@ public interface IDeviceClient
     /// Get all devices
     /// </summary>
     Task<IEnumerable<DeviceDto>> GetAllDevicesAsync(CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Get a device by ID
     /// </summary>
     Task<DeviceDto?> GetDeviceAsync(int id, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Create a new device
     /// </summary>
     Task<DeviceDto> CreateDeviceAsync(CreateDeviceRequest request, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Update an existing device
     /// </summary>
     Task<DeviceDto> UpdateDeviceAsync(int id, UpdateDeviceRequest request, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Delete a device
     /// </summary>
     Task DeleteDeviceAsync(int id, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Send a command to a device
     /// </summary>
     Task SendCommandAsync(int id, SendCommandRequest request, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Discover available Bluetooth devices
     /// </summary>
     Task<IEnumerable<string>> DiscoverBluetoothDevicesAsync(CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Start Bluetooth device scanning with real-time updates
     /// </summary>
     Task<BluetoothScanResponse> StartBluetoothScanAsync(BluetoothScanRequest request, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Start WebOS TV scanning with real-time updates
     /// </summary>

--- a/src/Zapper.Client.Abstractions/ZapperClientConfiguration.cs
+++ b/src/Zapper.Client.Abstractions/ZapperClientConfiguration.cs
@@ -9,17 +9,17 @@ public class ZapperClientConfiguration
     /// Base URL for the Zapper API
     /// </summary>
     public string BaseUrl { get; set; } = "http://localhost:5000";
-    
+
     /// <summary>
     /// Request timeout in seconds
     /// </summary>
     public int TimeoutSeconds { get; set; } = 30;
-    
+
     /// <summary>
     /// Number of retry attempts for failed requests
     /// </summary>
     public int RetryCount { get; set; } = 3;
-    
+
     /// <summary>
     /// API key for authentication (if required)
     /// </summary>

--- a/src/Zapper.Client/IDeviceApi.cs
+++ b/src/Zapper.Client/IDeviceApi.cs
@@ -15,49 +15,49 @@ public interface IDeviceApi
     /// </summary>
     [Get(ApiRoutes.Devices.GetAll)]
     Task<IEnumerable<DeviceDto>> GetAllDevicesAsync(CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Get a device by ID
     /// </summary>
     [Get(ApiRoutes.Devices.GetById)]
     Task<DeviceDto> GetDeviceAsync(int id, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Create a new device
     /// </summary>
     [Post(ApiRoutes.Devices.Create)]
     Task<DeviceDto> CreateDeviceAsync([Body] CreateDeviceRequest request, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Update an existing device
     /// </summary>
     [Put(ApiRoutes.Devices.Update)]
     Task<DeviceDto> UpdateDeviceAsync(int id, [Body] UpdateDeviceRequest request, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Delete a device
     /// </summary>
     [Delete(ApiRoutes.Devices.Delete)]
     Task DeleteDeviceAsync(int id, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Send a command to a device
     /// </summary>
     [Post(ApiRoutes.Devices.SendCommand)]
     Task SendCommandAsync(int id, [Body] SendCommandRequest request, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Discover available Bluetooth devices
     /// </summary>
     [Get(ApiRoutes.Devices.BluetoothDiscovery)]
     Task<IEnumerable<string>> DiscoverBluetoothDevicesAsync(CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Start Bluetooth device scanning with real-time updates
     /// </summary>
     [Post(ApiRoutes.Devices.BluetoothScan)]
     Task<BluetoothScanResponse> StartBluetoothScanAsync([Body] BluetoothScanRequest request, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Start WebOS TV scanning with real-time updates
     /// </summary>

--- a/src/Zapper.Client/ServiceCollectionExtensions.cs
+++ b/src/Zapper.Client/ServiceCollectionExtensions.cs
@@ -16,27 +16,27 @@ public static class ServiceCollectionExtensions
     /// <param name="configuration">Client configuration</param>
     /// <returns>The service collection for chaining</returns>
     public static IServiceCollection AddZapperApiClient(
-        this IServiceCollection services, 
+        this IServiceCollection services,
         ZapperClientConfiguration configuration)
     {
         // Register configuration
         services.AddSingleton(configuration);
-        
+
         // Register Refit API interfaces
         services.AddRefitClient<IDeviceApi>()
-            .ConfigureHttpClient(c => 
+            .ConfigureHttpClient(c =>
             {
                 c.BaseAddress = new Uri(configuration.BaseUrl);
                 c.Timeout = TimeSpan.FromSeconds(configuration.TimeoutSeconds);
             });
-        
+
         // Register client implementations
         services.AddScoped<IDeviceClient, DeviceClient>();
         services.AddScoped<IZapperApiClient, ZapperApiClient>();
-        
+
         return services;
     }
-    
+
     /// <summary>
     /// Add Zapper API client services with default configuration
     /// </summary>
@@ -44,7 +44,7 @@ public static class ServiceCollectionExtensions
     /// <param name="baseUrl">Base URL for the API (optional, defaults to localhost:5000)</param>
     /// <returns>The service collection for chaining</returns>
     public static IServiceCollection AddZapperApiClient(
-        this IServiceCollection services, 
+        this IServiceCollection services,
         string? baseUrl = null)
     {
         var configuration = new ZapperClientConfiguration();
@@ -52,7 +52,7 @@ public static class ServiceCollectionExtensions
         {
             configuration.BaseUrl = baseUrl;
         }
-        
+
         return services.AddZapperApiClient(configuration);
     }
 }

--- a/src/Zapper.Contracts/ApiRoutes.cs
+++ b/src/Zapper.Contracts/ApiRoutes.cs
@@ -3,7 +3,7 @@ namespace Zapper.Contracts;
 public static class ApiRoutes
 {
     public const string BaseUrl = "/api";
-    
+
     public static class Devices
     {
         public const string Base = $"{BaseUrl}/devices";
@@ -21,14 +21,14 @@ public static class ApiRoutes
         public const string BluetoothScan = $"{Base}/scan/bluetooth";
         public const string WebOSScan = $"{Base}/scan/webos";
     }
-    
+
     public static class Activities
     {
         public const string Base = $"{BaseUrl}/activities";
         public const string GetAll = Base;
         public const string Execute = $"{Base}/{{id}}/execute";
     }
-    
+
     public static class IRCodes
     {
         public const string Base = $"{BaseUrl}/ircodes";
@@ -43,7 +43,7 @@ public static class ApiRoutes
         public const string SearchSets = $"{Base}/sets/search";
         public const string SeedDefaults = $"{Base}/seed";
     }
-    
+
     public static class System
     {
         public const string Base = $"{BaseUrl}/system";

--- a/src/Zapper.Contracts/Devices/DeviceDto.cs
+++ b/src/Zapper.Contracts/Devices/DeviceDto.cs
@@ -5,50 +5,50 @@ namespace Zapper.Contracts.Devices;
 public class DeviceDto
 {
     public int Id { get; set; }
-    
+
     [Required]
     [MaxLength(100)]
     public string Name { get; set; } = string.Empty;
-    
+
     [Required]
     [MaxLength(50)]
     public string Brand { get; set; } = string.Empty;
-    
+
     [Required]
     [MaxLength(50)]
     public string Model { get; set; } = string.Empty;
-    
+
     [Required]
     public DeviceType Type { get; set; }
-    
+
     [Required]
     public ConnectionType ConnectionType { get; set; }
-    
+
     public string? IpAddress { get; set; }
-    
+
     public string? MacAddress { get; set; }
-    
+
     public int? Port { get; set; }
-    
+
     public string? AuthToken { get; set; }
-    
+
     public string? NetworkAddress { get; set; }
-    
+
     public string? AuthenticationToken { get; set; }
-    
+
     public bool UseSecureConnection { get; set; }
-    
+
     public string? BluetoothAddress { get; set; }
-    
+
     public bool SupportsMouseInput { get; set; }
-    
+
     public bool SupportsKeyboardInput { get; set; }
-    
+
     public string? IrCodeSet { get; set; }
-    
+
     public bool IsOnline { get; set; }
-    
+
     public DateTime CreatedAt { get; set; }
-    
+
     public DateTime LastSeen { get; set; }
 }

--- a/src/Zapper.Core/Models/Activity.cs
+++ b/src/Zapper.Core/Models/Activity.cs
@@ -5,25 +5,25 @@ namespace Zapper.Core.Models;
 public class Activity
 {
     public int Id { get; set; }
-    
+
     [Required]
     [MaxLength(100)]
     public string Name { get; set; } = string.Empty;
-    
+
     [MaxLength(500)]
     public string? Description { get; set; }
-    
+
     public string? IconUrl { get; set; }
-    
+
     public bool IsEnabled { get; set; } = true;
-    
+
     public int SortOrder { get; set; }
-    
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    
+
     public DateTime LastUsed { get; set; } = DateTime.UtcNow;
-    
+
     public ICollection<ActivityDevice> ActivityDevices { get; set; } = new List<ActivityDevice>();
-    
+
     public ICollection<ActivityStep> Steps { get; set; } = new List<ActivityStep>();
 }

--- a/src/Zapper.Core/Models/ActivityDevice.cs
+++ b/src/Zapper.Core/Models/ActivityDevice.cs
@@ -3,14 +3,14 @@ namespace Zapper.Core.Models;
 public class ActivityDevice
 {
     public int Id { get; set; }
-    
+
     public int ActivityId { get; set; }
-    
+
     public int DeviceId { get; set; }
-    
+
     public bool IsPrimaryDevice { get; set; }
-    
+
     public Activity Activity { get; set; } = null!;
-    
+
     public Device Device { get; set; } = null!;
 }

--- a/src/Zapper.Core/Models/ActivityStep.cs
+++ b/src/Zapper.Core/Models/ActivityStep.cs
@@ -3,20 +3,20 @@ namespace Zapper.Core.Models;
 public class ActivityStep
 {
     public int Id { get; set; }
-    
+
     public int ActivityId { get; set; }
-    
+
     public int DeviceCommandId { get; set; }
-    
+
     public int StepOrder { get; set; }
-    
+
     public int DelayBeforeMs { get; set; } = 0;
-    
+
     public int DelayAfterMs { get; set; } = 0;
-    
+
     public bool IsRequired { get; set; } = true;
-    
+
     public Activity Activity { get; set; } = null!;
-    
+
     public DeviceCommand DeviceCommand { get; set; } = null!;
 }

--- a/src/Zapper.Core/Models/Device.cs
+++ b/src/Zapper.Core/Models/Device.cs
@@ -5,54 +5,54 @@ namespace Zapper.Core.Models;
 public class Device
 {
     public int Id { get; set; }
-    
+
     [Required]
     [MaxLength(100)]
     public string Name { get; set; } = string.Empty;
-    
+
     [Required]
     [MaxLength(50)]
     public string Brand { get; set; } = string.Empty;
-    
+
     [Required]
     [MaxLength(50)]
     public string Model { get; set; } = string.Empty;
-    
+
     [Required]
     public DeviceType Type { get; set; }
-    
+
     [Required]
     public ConnectionType ConnectionType { get; set; }
-    
+
     public string? IpAddress { get; set; }
-    
+
     public string? MacAddress { get; set; }
-    
+
     public int? Port { get; set; }
-    
+
     public string? AuthToken { get; set; }
-    
+
     public string? NetworkAddress { get; set; }
-    
+
     public string? AuthenticationToken { get; set; }
-    
+
     public bool UseSecureConnection { get; set; }
-    
+
     public string? BluetoothAddress { get; set; }
-    
+
     public bool SupportsMouseInput { get; set; }
-    
+
     public bool SupportsKeyboardInput { get; set; }
-    
+
     public string? IrCodeSet { get; set; }
-    
+
     public bool IsOnline { get; set; }
-    
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    
+
     public DateTime LastSeen { get; set; } = DateTime.UtcNow;
-    
+
     public ICollection<DeviceCommand> Commands { get; set; } = new List<DeviceCommand>();
-    
+
     public ICollection<ActivityDevice> ActivityDevices { get; set; } = new List<ActivityDevice>();
 }

--- a/src/Zapper.Core/Models/DeviceCommand.cs
+++ b/src/Zapper.Core/Models/DeviceCommand.cs
@@ -5,36 +5,36 @@ namespace Zapper.Core.Models;
 public class DeviceCommand
 {
     public int Id { get; set; }
-    
+
     public int DeviceId { get; set; }
-    
+
     [Required]
     [MaxLength(50)]
     public string Name { get; set; } = string.Empty;
-    
+
     [Required]
     public CommandType Type { get; set; }
-    
+
     public string? IrCode { get; set; }
-    
+
     public string? NetworkPayload { get; set; }
-    
+
     public string? HttpMethod { get; set; }
-    
+
     public string? HttpEndpoint { get; set; }
-    
+
     public int DelayMs { get; set; } = 0;
-    
+
     public bool IsRepeatable { get; set; } = false;
-    
+
     public int? MouseDeltaX { get; set; }
-    
+
     public int? MouseDeltaY { get; set; }
-    
+
     public string? KeyboardText { get; set; }
-    
+
     public Device Device { get; set; } = null!;
-    
+
     public ICollection<ActivityStep> ActivitySteps { get; set; } = new List<ActivityStep>();
 }
 

--- a/src/Zapper.Core/Models/IRCode.cs
+++ b/src/Zapper.Core/Models/IRCode.cs
@@ -5,58 +5,58 @@ namespace Zapper.Core.Models;
 public class IrCode
 {
     public int Id { get; set; }
-    
+
     [Required]
     public string Brand { get; set; } = string.Empty;
-    
+
     [Required]
     public string Model { get; set; } = string.Empty;
-    
+
     [Required]
     public DeviceType DeviceType { get; set; }
-    
+
     [Required]
     public string CommandName { get; set; } = string.Empty;
-    
+
     [Required]
     public string Protocol { get; set; } = string.Empty;
-    
+
     [Required]
     public string HexCode { get; set; } = string.Empty;
-    
+
     public int Frequency { get; set; } = 38000;
-    
+
     public string? RawData { get; set; }
-    
+
     public string? Notes { get; set; }
-    
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    
+
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }
 
 public class IrCodeSet
 {
     public int Id { get; set; }
-    
+
     [Required]
     public string Brand { get; set; } = string.Empty;
-    
+
     [Required]
     public string Model { get; set; } = string.Empty;
-    
+
     [Required]
     public DeviceType DeviceType { get; set; }
-    
+
     public string? Description { get; set; }
-    
+
     public bool IsVerified { get; set; }
-    
+
     public int DownloadCount { get; set; }
-    
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    
+
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
-    
+
     public List<IrCode> Codes { get; set; } = new();
 }

--- a/src/Zapper.Data/ZapperContext.cs
+++ b/src/Zapper.Data/ZapperContext.cs
@@ -5,7 +5,7 @@ namespace Zapper.Data;
 
 public class ZapperContext(DbContextOptions<ZapperContext> options) : DbContext(options)
 {
-    
+
     public DbSet<Device> Devices { get; set; }
     public DbSet<DeviceCommand> DeviceCommands { get; set; }
     public DbSet<Activity> Activities { get; set; }
@@ -13,7 +13,7 @@ public class ZapperContext(DbContextOptions<ZapperContext> options) : DbContext(
     public DbSet<ActivityStep> ActivitySteps { get; set; }
     public DbSet<IrCode> IrCodes { get; set; }
     public DbSet<IrCodeSet> IrCodeSets { get; set; }
-    
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<Device>(entity =>
@@ -24,7 +24,7 @@ public class ZapperContext(DbContextOptions<ZapperContext> options) : DbContext(
             entity.Property(e => e.Type).HasConversion<string>();
             entity.Property(e => e.ConnectionType).HasConversion<string>();
         });
-        
+
         modelBuilder.Entity<DeviceCommand>(entity =>
         {
             entity.HasKey(e => e.Id);
@@ -35,14 +35,14 @@ public class ZapperContext(DbContextOptions<ZapperContext> options) : DbContext(
                 .HasForeignKey(e => e.DeviceId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
-        
+
         modelBuilder.Entity<Activity>(entity =>
         {
             entity.HasKey(e => e.Id);
             entity.HasIndex(e => e.Name).IsUnique();
             entity.HasIndex(e => e.SortOrder);
         });
-        
+
         modelBuilder.Entity<ActivityDevice>(entity =>
         {
             entity.HasKey(e => e.Id);
@@ -56,7 +56,7 @@ public class ZapperContext(DbContextOptions<ZapperContext> options) : DbContext(
                 .HasForeignKey(e => e.DeviceId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
-        
+
         modelBuilder.Entity<ActivityStep>(entity =>
         {
             entity.HasKey(e => e.Id);
@@ -70,14 +70,14 @@ public class ZapperContext(DbContextOptions<ZapperContext> options) : DbContext(
                 .HasForeignKey(e => e.DeviceCommandId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
-        
+
         modelBuilder.Entity<IrCode>(entity =>
         {
             entity.HasKey(e => e.Id);
             entity.HasIndex(e => new { e.Brand, e.Model, e.CommandName });
             entity.Property(e => e.DeviceType).HasConversion<string>();
         });
-        
+
         modelBuilder.Entity<IrCodeSet>(entity =>
         {
             entity.HasKey(e => e.Id);

--- a/src/Zapper.Device.Bluetooth.Tests.Unit/AndroidTVBluetoothControllerTests.cs
+++ b/src/Zapper.Device.Bluetooth.Tests.Unit/AndroidTVBluetoothControllerTests.cs
@@ -158,8 +158,8 @@ public class AndroidTvBluetoothControllerTests
     {
         // Arrange
         var device = CreateTestBluetoothDevice();
-        var command = new DeviceCommand 
-        { 
+        var command = new DeviceCommand
+        {
             Type = CommandType.Number,
             NetworkPayload = "5"
         };
@@ -182,8 +182,8 @@ public class AndroidTvBluetoothControllerTests
     {
         // Arrange
         var device = CreateTestBluetoothDevice();
-        var command = new DeviceCommand 
-        { 
+        var command = new DeviceCommand
+        {
             Type = CommandType.Custom,
             NetworkPayload = "text:Hello World"
         };
@@ -206,8 +206,8 @@ public class AndroidTvBluetoothControllerTests
     {
         // Arrange
         var device = CreateTestBluetoothDevice();
-        var command = new DeviceCommand 
-        { 
+        var command = new DeviceCommand
+        {
             Type = CommandType.Custom,
             NetworkPayload = "netflix"
         };
@@ -215,7 +215,7 @@ public class AndroidTvBluetoothControllerTests
         _mockHidController.IsConnectedAsync(device.MacAddress!, Arg.Any<CancellationToken>())
             .Returns(true);
         _mockHidController.SendKeySequenceAsync(
-            device.MacAddress!, 
+            device.MacAddress!,
             Arg.Is<HidKeyCode[]>(keys => keys.SequenceEqual(new[] { HidKeyCode.Home, HidKeyCode.N })),
             100,
             Arg.Any<CancellationToken>())
@@ -227,7 +227,7 @@ public class AndroidTvBluetoothControllerTests
         // Assert
         result.Should().BeTrue();
         await _mockHidController.Received(1).SendKeySequenceAsync(
-            device.MacAddress!, 
+            device.MacAddress!,
             Arg.Is<HidKeyCode[]>(keys => keys.SequenceEqual(new[] { HidKeyCode.Home, HidKeyCode.N })),
             100,
             Arg.Any<CancellationToken>());

--- a/src/Zapper.Device.Bluetooth/AndroidTVBluetoothController.cs
+++ b/src/Zapper.Device.Bluetooth/AndroidTVBluetoothController.cs
@@ -14,7 +14,7 @@ public class AndroidTvBluetoothController : IBluetoothDeviceController
         ArgumentNullException.ThrowIfNull(hidController);
         ArgumentNullException.ThrowIfNull(bluetoothService);
         ArgumentNullException.ThrowIfNull(logger);
-        
+
         this.hidController = hidController;
         this.bluetoothService = bluetoothService;
         this.logger = logger;
@@ -75,7 +75,7 @@ public class AndroidTvBluetoothController : IBluetoothDeviceController
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to send Bluetooth command {CommandType} to device {DeviceName}", 
+            logger.LogError(ex, "Failed to send Bluetooth command {CommandType} to device {DeviceName}",
                 command.Type, device.Name);
             return false;
         }
@@ -203,20 +203,20 @@ public class AndroidTvBluetoothController : IBluetoothDeviceController
                 case "netflix":
                     return await hidController.SendKeySequenceAsync(deviceAddress,
                         [HidKeyCode.Home, HidKeyCode.N], 100, cancellationToken);
-                
+
                 case "youtube":
                     return await hidController.SendKeySequenceAsync(deviceAddress,
                         [HidKeyCode.Home, HidKeyCode.Y], 100, cancellationToken);
-                
+
                 case "assistant":
                     return await hidController.SendKeyAsync(deviceAddress, HidKeyCode.Assistant, cancellationToken);
-                
+
                 case "search":
                     return await hidController.SendKeyAsync(deviceAddress, HidKeyCode.Search, cancellationToken);
-                
+
                 case "settings":
                     return await hidController.SendKeyAsync(deviceAddress, HidKeyCode.Settings, cancellationToken);
-                
+
                 default:
                     if (Enum.TryParse<HidKeyCode>(command.NetworkPayload, true, out var keyCode))
                     {
@@ -245,12 +245,12 @@ public class AndroidTvBluetoothController : IBluetoothDeviceController
     {
         var name = device.Name?.ToLowerInvariant() ?? "";
         var alias = device.Alias?.ToLowerInvariant() ?? "";
-        
-        return name.Contains("android tv") || 
-               name.Contains("chromecast") || 
+
+        return name.Contains("android tv") ||
+               name.Contains("chromecast") ||
                name.Contains("google tv") ||
-               alias.Contains("android tv") || 
-               alias.Contains("chromecast") || 
+               alias.Contains("android tv") ||
+               alias.Contains("chromecast") ||
                alias.Contains("google tv") ||
                device.UuiDs.Any(uuid => IsAndroidTvServiceUuid(uuid));
     }

--- a/src/Zapper.Device.Bluetooth/AppleTVBluetoothController.cs
+++ b/src/Zapper.Device.Bluetooth/AppleTVBluetoothController.cs
@@ -62,7 +62,7 @@ public class AppleTvBluetoothController(IBluetoothHidController hidController, I
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to send Bluetooth command {CommandType} to device {DeviceName}", 
+            logger.LogError(ex, "Failed to send Bluetooth command {CommandType} to device {DeviceName}",
                 command.Type, device.Name);
             return false;
         }
@@ -190,33 +190,33 @@ public class AppleTvBluetoothController(IBluetoothHidController hidController, I
             {
                 case "siri":
                     return await hidController.SendKeyAsync(deviceAddress, HidKeyCode.Assistant, cancellationToken);
-                
+
                 case "app_switcher":
                     return await hidController.SendKeySequenceAsync(deviceAddress,
                         [HidKeyCode.Home, HidKeyCode.Home], 200, cancellationToken);
-                
+
                 case "control_center":
                     return await hidController.SendKeyAsync(deviceAddress, HidKeyCode.Menu, cancellationToken);
-                
+
                 case "netflix":
                     return await hidController.SendKeySequenceAsync(deviceAddress,
                         [HidKeyCode.Home, HidKeyCode.N], 100, cancellationToken);
-                
+
                 case "disney":
                 case "disney+":
                     return await hidController.SendKeySequenceAsync(deviceAddress,
                         [HidKeyCode.Home, HidKeyCode.D], 100, cancellationToken);
-                
+
                 case "youtube":
                     return await hidController.SendKeySequenceAsync(deviceAddress,
                         [HidKeyCode.Home, HidKeyCode.Y], 100, cancellationToken);
-                
+
                 case "search":
                     return await hidController.SendKeyAsync(deviceAddress, HidKeyCode.Search, cancellationToken);
-                
+
                 case "settings":
                     return await hidController.SendKeyAsync(deviceAddress, HidKeyCode.Settings, cancellationToken);
-                
+
                 default:
                     if (Enum.TryParse<HidKeyCode>(command.NetworkPayload, true, out var keyCode))
                     {
@@ -245,13 +245,13 @@ public class AppleTvBluetoothController(IBluetoothHidController hidController, I
     {
         var name = device.Name?.ToLowerInvariant() ?? "";
         var alias = device.Alias?.ToLowerInvariant() ?? "";
-        
-        return name.Contains("apple tv") || 
-               name.Contains("appletv") || 
+
+        return name.Contains("apple tv") ||
+               name.Contains("appletv") ||
                name.Contains("siri remote") ||
                name.Contains("apple remote") ||
-               alias.Contains("apple tv") || 
-               alias.Contains("appletv") || 
+               alias.Contains("apple tv") ||
+               alias.Contains("appletv") ||
                alias.Contains("siri remote") ||
                alias.Contains("apple remote") ||
                device.UuiDs.Any(uuid => IsAppleTvServiceUuid(uuid));

--- a/src/Zapper.Device.Bluetooth/BlueZAdapter.cs
+++ b/src/Zapper.Device.Bluetooth/BlueZAdapter.cs
@@ -23,10 +23,10 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
         try
         {
             logger.LogInformation("Initializing BlueZ adapter...");
-            
+
             var adapters = await BlueZManager.GetAdaptersAsync();
             _adapter = adapters.FirstOrDefault();
-            
+
             if (_adapter == null)
             {
                 throw new InvalidOperationException("No Bluetooth adapters found on the system");
@@ -35,11 +35,11 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
             logger.LogInformation("Found Bluetooth adapter: {Address}", await _adapter.GetAddressAsync());
 
             if (!await _adapter.GetAsync<bool>("Powered"))
-            if (!await _adapter.GetAsync<bool>("Powered"))
-            {
-                logger.LogInformation("Powering on Bluetooth adapter...");
-                await _adapter.SetAsync("Powered", true);
-            }
+                if (!await _adapter.GetAsync<bool>("Powered"))
+                {
+                    logger.LogInformation("Powering on Bluetooth adapter...");
+                    await _adapter.SetAsync("Powered", true);
+                }
 
             logger.LogInformation("BlueZ adapter initialized successfully");
         }
@@ -152,7 +152,7 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
         {
             var devices = await _adapter.GetDevicesAsync();
             var device = devices.FirstOrDefault(d => d.GetAsync<string>("Address").GetAwaiter().GetResult() == address);
-            
+
             if (device == null)
                 return null;
 
@@ -174,7 +174,7 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
         {
             var devices = await _adapter.GetDevicesAsync();
             var device = devices.FirstOrDefault(d => d.GetAsync<string>("Address").GetAwaiter().GetResult() == address);
-            
+
             if (device == null)
             {
                 logger.LogWarning("Device {Address} not found for pairing", address);
@@ -189,10 +189,10 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
 
             logger.LogInformation("Pairing with device {Address}...", address);
             await device.PairAsync();
-            
+
             var isPaired = await device.GetAsync<bool>("Paired");
             logger.LogInformation("Pairing with device {Address} {Result}", address, isPaired ? "succeeded" : "failed");
-            
+
             return isPaired;
         }
         catch (Exception ex)
@@ -211,7 +211,7 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
         {
             var devices = await _adapter.GetDevicesAsync();
             var device = devices.FirstOrDefault(d => d.GetAsync<string>("Address").GetAwaiter().GetResult() == address);
-            
+
             if (device == null)
             {
                 logger.LogWarning("Device {Address} not found for connection", address);
@@ -226,16 +226,16 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
 
             logger.LogInformation("Connecting to device {Address}...", address);
             await device.ConnectAsync();
-            
+
             var isConnected = await device.GetAsync<bool>("Connected");
             logger.LogInformation("Connection to device {Address} {Result}", address, isConnected ? "succeeded" : "failed");
-            
+
             if (isConnected)
             {
                 _devices[address] = device;
                 DeviceConnected?.Invoke(this, new BluetoothDeviceEventArgs(await CreateDeviceInfoAsync(device)));
             }
-            
+
             return isConnected;
         }
         catch (Exception ex)
@@ -254,7 +254,7 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
         {
             var devices = await _adapter.GetDevicesAsync();
             var device = devices.FirstOrDefault(d => d.GetAsync<string>("Address").GetAwaiter().GetResult() == address);
-            
+
             if (device == null)
             {
                 logger.LogWarning("Device {Address} not found for disconnection", address);
@@ -269,16 +269,16 @@ public class BlueZAdapter(ILogger<BlueZAdapter> logger) : IDisposable
 
             logger.LogInformation("Disconnecting from device {Address}...", address);
             await device.DisconnectAsync();
-            
+
             var isConnected = await device.GetAsync<bool>("Connected");
             logger.LogInformation("Disconnection from device {Address} {Result}", address, !isConnected ? "succeeded" : "failed");
-            
+
             if (!isConnected)
             {
                 _devices.Remove(address);
                 DeviceDisconnected?.Invoke(this, new BluetoothDeviceEventArgs(await CreateDeviceInfoAsync(device)));
             }
-            
+
             return !isConnected;
         }
         catch (Exception ex)

--- a/src/Zapper.Device.Bluetooth/BluetoothHidController.cs
+++ b/src/Zapper.Device.Bluetooth/BluetoothHidController.cs
@@ -32,13 +32,13 @@ public class BluetoothHidController : IBluetoothHidController
 
             if (IsHidDevice(device))
             {
-                _logger.LogInformation("Simulating HID key {KeyCode} sent to device {Address} ({Name})", 
+                _logger.LogInformation("Simulating HID key {KeyCode} sent to device {Address} ({Name})",
                     keyCode, deviceAddress, device.Name);
                 return true;
             }
             else
             {
-                _logger.LogWarning("Device {Address} ({Name}) does not support HID profile", 
+                _logger.LogWarning("Device {Address} ({Name}) does not support HID profile",
                     deviceAddress, device.Name);
                 return false;
             }
@@ -63,21 +63,21 @@ public class BluetoothHidController : IBluetoothHidController
 
             if (!IsHidDevice(device))
             {
-                _logger.LogWarning("Device {Address} ({Name}) does not support HID profile", 
+                _logger.LogWarning("Device {Address} ({Name}) does not support HID profile",
                     deviceAddress, device.Name);
                 return false;
             }
 
-            _logger.LogDebug("Sending HID key sequence to device {Address}: {Keys}", 
+            _logger.LogDebug("Sending HID key sequence to device {Address}: {Keys}",
                 deviceAddress, string.Join(", ", keyCodes));
 
             foreach (var keyCode in keyCodes)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                
+
                 if (!await SendKeyAsync(deviceAddress, keyCode, cancellationToken))
                 {
-                    _logger.LogWarning("Failed to send key {KeyCode} in sequence to device {Address}", 
+                    _logger.LogWarning("Failed to send key {KeyCode} in sequence to device {Address}",
                         keyCode, deviceAddress);
                     return false;
                 }
@@ -118,7 +118,7 @@ public class BluetoothHidController : IBluetoothHidController
 
             if (!IsHidDevice(device))
             {
-                _logger.LogWarning("Device {Address} ({Name}) does not support HID profile", 
+                _logger.LogWarning("Device {Address} ({Name}) does not support HID profile",
                     deviceAddress, device.Name);
                 return false;
             }

--- a/src/Zapper.Device.Bluetooth/BluetoothService.cs
+++ b/src/Zapper.Device.Bluetooth/BluetoothService.cs
@@ -36,7 +36,7 @@ public class BluetoothService : BackgroundService, IBluetoothService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         var loggerFactoryNotNull = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _adapter = new BlueZAdapter(loggerFactoryNotNull.CreateLogger<BlueZAdapter>());
-        
+
         _adapter.DeviceFound += (s, e) => DeviceFound?.Invoke(this, e);
         _adapter.DeviceConnected += (s, e) => DeviceConnected?.Invoke(this, e);
         _adapter.DeviceDisconnected += (s, e) => DeviceDisconnected?.Invoke(this, e);
@@ -188,7 +188,7 @@ public class BluetoothService : BackgroundService, IBluetoothService
         try
         {
             await InitializeAsync(stoppingToken);
-            
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 await Task.Delay(1000, stoppingToken);

--- a/src/Zapper.Device.Bluetooth/IBluetoothHIDController.cs
+++ b/src/Zapper.Device.Bluetooth/IBluetoothHIDController.cs
@@ -14,7 +14,7 @@ public interface IBluetoothHidController
 public enum HidKeyCode
 {
     None = 0x00,
-    
+
     A = 0x04,
     B = 0x05,
     C = 0x06,
@@ -41,7 +41,7 @@ public enum HidKeyCode
     X = 0x1B,
     Y = 0x1C,
     Z = 0x1D,
-    
+
     Key1 = 0x1E,
     Key2 = 0x1F,
     Key3 = 0x20,
@@ -52,36 +52,36 @@ public enum HidKeyCode
     Key8 = 0x25,
     Key9 = 0x26,
     Key0 = 0x27,
-    
+
     Enter = 0x28,
     Escape = 0x29,
     Backspace = 0x2A,
     Tab = 0x2B,
     Space = 0x2C,
-    
+
     DPadUp = 0x52,
     DPadDown = 0x51,
     DPadLeft = 0x50,
     DPadRight = 0x4F,
     DPadCenter = 0x28,
-    
+
     ArrowUp = DPadUp,
     ArrowDown = DPadDown,
     ArrowLeft = DPadLeft,
     ArrowRight = DPadRight,
-    
+
     PageUp = 0x4B,
     PageDown = 0x4E,
-    
+
     Back = 0x29,
     Home = 0x4A,
     Menu = 0x76,
     Delete = 0x4C,
-    
+
     VolumeUp = 0x80,
     VolumeDown = 0x81,
     VolumeMute = 0x7F,
-    
+
     PlayPause = 0xCD,
     Play = 0xB0,
     Pause = 0xB1,
@@ -90,11 +90,11 @@ public enum HidKeyCode
     Rewind = 0xB4,
     NextTrack = 0xB5,
     PreviousTrack = 0xB6,
-    
+
     Assistant = 0xAE,
     Search = 0x221,
     Settings = 0x222,
-    
+
     F1 = 0x3A,
     F2 = 0x3B,
     F3 = 0x3C,

--- a/src/Zapper.Device.Bluetooth/ServiceCollectionExtensions.cs
+++ b/src/Zapper.Device.Bluetooth/ServiceCollectionExtensions.cs
@@ -8,16 +8,16 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddBluetoothServices(this IServiceCollection services)
     {
         services.AddSingleton<IBluetoothService, BluetoothService>();
-        services.AddSingleton<IHostedService>(provider => 
+        services.AddSingleton<IHostedService>(provider =>
             (BluetoothService)provider.GetRequiredService<IBluetoothService>());
-        
+
         services.AddSingleton<IBluetoothHidController, BluetoothHidController>();
-        
+
         services.AddSingleton<IBluetoothDeviceController, AndroidTvBluetoothController>();
         services.AddSingleton<AndroidTvBluetoothController>();
         services.AddSingleton<IBluetoothDeviceController, AppleTvBluetoothController>();
         services.AddSingleton<AppleTvBluetoothController>();
-        
+
         return services;
     }
 }

--- a/src/Zapper.Device.Infrared.Tests.Unit/GpioInfraredTransmitterTests.cs
+++ b/src/Zapper.Device.Infrared.Tests.Unit/GpioInfraredTransmitterTests.cs
@@ -18,7 +18,7 @@ public class GpioInfraredTransmitterTests
     public void IsAvailable_WhenNotInitialized_ShouldReturnFalse()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         transmitter.IsAvailable.Should().BeFalse();
     }
 
@@ -26,9 +26,9 @@ public class GpioInfraredTransmitterTests
     public async Task TransmitAsync_WhenNotInitialized_ShouldThrowInvalidOperationException()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         var act = async () => await transmitter.TransmitAsync("test code", 1);
-        
+
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("IR transmitter not initialized");
     }
@@ -45,9 +45,9 @@ public class GpioInfraredTransmitterTests
             HexCode = "0x123456",
             Protocol = "NEC"
         };
-        
+
         var act = async () => await transmitter.TransmitAsync(irCode, 1);
-        
+
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("IR transmitter not initialized");
     }
@@ -57,9 +57,9 @@ public class GpioInfraredTransmitterTests
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
         var pulses = new[] { 9000, 4500, 560, 560 };
-        
+
         var act = async () => await transmitter.TransmitRawAsync(pulses, 38000);
-        
+
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("IR transmitter not initialized");
     }
@@ -68,13 +68,13 @@ public class GpioInfraredTransmitterTests
     public void ParseIrCode_WithValidSpaceSeparatedValues_ShouldReturnCorrectArray()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         // Use reflection to access private method for testing
-        var method = typeof(GpioInfraredTransmitter).GetMethod("ParseIrCode", 
+        var method = typeof(GpioInfraredTransmitter).GetMethod("ParseIrCode",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         var result = (int[])method!.Invoke(transmitter, ["9000 4500 560 560"])!;
-        
+
         result.Should().Equal(9000, 4500, 560, 560);
     }
 
@@ -82,13 +82,13 @@ public class GpioInfraredTransmitterTests
     public void ParseIrCode_WithInvalidValues_ShouldThrowArgumentException()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         // Use reflection to access private method for testing
-        var method = typeof(GpioInfraredTransmitter).GetMethod("ParseIrCode", 
+        var method = typeof(GpioInfraredTransmitter).GetMethod("ParseIrCode",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         var act = () => method!.Invoke(transmitter, ["invalid data"]);
-        
+
         act.Should().Throw<System.Reflection.TargetInvocationException>()
            .WithInnerException<ArgumentException>()
            .WithMessage("Invalid IR code format*");
@@ -102,13 +102,13 @@ public class GpioInfraredTransmitterTests
     public void ConvertHexToPulses_WithSupportedProtocols_ShouldReturnPulseArray(string protocol)
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         // Use reflection to access private method for testing
-        var method = typeof(GpioInfraredTransmitter).GetMethod("ConvertHexToPulses", 
+        var method = typeof(GpioInfraredTransmitter).GetMethod("ConvertHexToPulses",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         var result = (int[])method!.Invoke(transmitter, ["0x123456", protocol])!;
-        
+
         result.Should().NotBeEmpty();
         result.Should().AllSatisfy(pulse => pulse.Should().BeGreaterThan(0));
     }
@@ -117,13 +117,13 @@ public class GpioInfraredTransmitterTests
     public void ConvertHexToPulses_WithUnsupportedProtocol_ShouldThrowNotSupportedException()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         // Use reflection to access private method for testing
-        var method = typeof(GpioInfraredTransmitter).GetMethod("ConvertHexToPulses", 
+        var method = typeof(GpioInfraredTransmitter).GetMethod("ConvertHexToPulses",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         var act = () => method!.Invoke(transmitter, ["0x123456", "UNKNOWN"]);
-        
+
         act.Should().Throw<System.Reflection.TargetInvocationException>()
            .WithInnerException<NotSupportedException>()
            .WithMessage("Protocol UNKNOWN not supported");
@@ -133,18 +133,18 @@ public class GpioInfraredTransmitterTests
     public void ConvertNecToPulses_ShouldGenerateCorrectStructure()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         // Use reflection to access private method for testing
-        var method = typeof(GpioInfraredTransmitter).GetMethod("ConvertNecToPulses", 
+        var method = typeof(GpioInfraredTransmitter).GetMethod("ConvertNecToPulses",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         var result = (int[])method!.Invoke(transmitter, [0x00FF00FFU])!;
-        
+
         // NEC should start with header (9000, 4500) and end with stop bit (560)
         result[0].Should().Be(9000); // Header mark
         result[1].Should().Be(4500); // Header space
         result[^1].Should().Be(560); // Stop bit
-        
+
         // Should have 67 total pulses (header + 32 data bits + stop)
         result.Length.Should().Be(67);
     }
@@ -153,17 +153,17 @@ public class GpioInfraredTransmitterTests
     public void ConvertSonyToPulses_ShouldGenerateCorrectStructure()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         // Use reflection to access private method for testing
-        var method = typeof(GpioInfraredTransmitter).GetMethod("ConvertSonyToPulses", 
+        var method = typeof(GpioInfraredTransmitter).GetMethod("ConvertSonyToPulses",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         var result = (int[])method!.Invoke(transmitter, [0xA90U])!;
-        
+
         // Sony should start with header (2400, 600)
         result[0].Should().Be(2400); // Header mark
         result[1].Should().Be(600);  // Header space
-        
+
         // Should have 26 total pulses (header + 12 data bits)
         result.Length.Should().Be(26);
     }
@@ -172,9 +172,9 @@ public class GpioInfraredTransmitterTests
     public void Dispose_ShouldLogDisposalMessage()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         transmitter.Dispose();
-        
+
         // Logger assertions removed - using NullLogger for simplicity
     }
 
@@ -182,13 +182,13 @@ public class GpioInfraredTransmitterTests
     public void Dispose_CalledMultipleTimes_ShouldNotThrow()
     {
         var transmitter = new GpioInfraredTransmitter(18, _logger);
-        
+
         var act = () =>
         {
             transmitter.Dispose();
             transmitter.Dispose();
         };
-        
+
         act.Should().NotThrow();
     }
 }

--- a/src/Zapper.Device.Infrared.Tests.Unit/InfraredDeviceControllerTests.cs
+++ b/src/Zapper.Device.Infrared.Tests.Unit/InfraredDeviceControllerTests.cs
@@ -79,9 +79,9 @@ public class InfraredDeviceControllerTests
             Name = "Samsung TV",
             ConnectionType = ConnectionType.InfraredIr
         };
-        var command = new DeviceCommand 
-        { 
-            Name = "Power", 
+        var command = new DeviceCommand
+        {
+            Name = "Power",
             IrCode = "9000 4500 560 560",
             IsRepeatable = false,
             DelayMs = 0
@@ -106,9 +106,9 @@ public class InfraredDeviceControllerTests
             Name = "Samsung TV",
             ConnectionType = ConnectionType.InfraredIr
         };
-        var command = new DeviceCommand 
-        { 
-            Name = "VolumeUp", 
+        var command = new DeviceCommand
+        {
+            Name = "VolumeUp",
             IrCode = "9000 4500 560 560",
             IsRepeatable = true,
             DelayMs = 0
@@ -132,9 +132,9 @@ public class InfraredDeviceControllerTests
             Name = "Samsung TV",
             ConnectionType = ConnectionType.InfraredIr
         };
-        var command = new DeviceCommand 
-        { 
-            Name = "Power", 
+        var command = new DeviceCommand
+        {
+            Name = "Power",
             IrCode = "9000 4500 560 560",
             IsRepeatable = false,
             DelayMs = 100
@@ -160,9 +160,9 @@ public class InfraredDeviceControllerTests
             Name = "Samsung TV",
             ConnectionType = ConnectionType.InfraredIr
         };
-        var command = new DeviceCommand 
-        { 
-            Name = "Power", 
+        var command = new DeviceCommand
+        {
+            Name = "Power",
             IrCode = "9000 4500 560 560"
         };
 

--- a/src/Zapper.Device.Infrared.Tests.Unit/MockInfraredTransmitterTests.cs
+++ b/src/Zapper.Device.Infrared.Tests.Unit/MockInfraredTransmitterTests.cs
@@ -26,7 +26,7 @@ public class MockInfraredTransmitterTests
     public void IsAvailable_WhenInitialized_ShouldReturnTrue()
     {
         _transmitter.Initialize();
-        
+
         _transmitter.IsAvailable.Should().BeTrue();
     }
 
@@ -34,7 +34,7 @@ public class MockInfraredTransmitterTests
     public void Initialize_ShouldLogInitializationMessage()
     {
         _transmitter.Initialize();
-        
+
         // Logger assertions removed - using NullLogger for simplicity
         // In a real scenario, you would use a test logger framework
     }
@@ -43,7 +43,7 @@ public class MockInfraredTransmitterTests
     public async Task TransmitAsync_WithString_WhenNotInitialized_ShouldThrowInvalidOperationException()
     {
         var act = async () => await _transmitter.TransmitAsync("test code", 1);
-        
+
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Mock IR transmitter not initialized");
     }
@@ -53,12 +53,12 @@ public class MockInfraredTransmitterTests
     {
         _transmitter.Initialize();
         var startTime = DateTime.UtcNow;
-        
+
         await _transmitter.TransmitAsync("test code", 2);
-        
+
         var elapsed = DateTime.UtcNow - startTime;
         elapsed.Should().BeGreaterThan(TimeSpan.FromMilliseconds(150)); // 2 * 100ms - some tolerance
-        
+
         // Logger assertions removed - using NullLogger for simplicity
     }
 
@@ -72,9 +72,9 @@ public class MockInfraredTransmitterTests
             CommandName = "Power",
             HexCode = "0x123456"
         };
-        
+
         var act = async () => await _transmitter.TransmitAsync(irCode, 1);
-        
+
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Mock IR transmitter not initialized");
     }
@@ -90,9 +90,9 @@ public class MockInfraredTransmitterTests
             CommandName = "Power",
             HexCode = "0xE0E040BF"
         };
-        
+
         await _transmitter.TransmitAsync(irCode, 1);
-        
+
         // Logger assertions removed - using NullLogger for simplicity
     }
 
@@ -100,9 +100,9 @@ public class MockInfraredTransmitterTests
     public async Task TransmitRawAsync_WhenNotInitialized_ShouldThrowInvalidOperationException()
     {
         var pulses = new[] { 9000, 4500, 560, 560 };
-        
+
         var act = async () => await _transmitter.TransmitRawAsync(pulses, 38000);
-        
+
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Mock IR transmitter not initialized");
     }
@@ -112,9 +112,9 @@ public class MockInfraredTransmitterTests
     {
         _transmitter.Initialize();
         var pulses = new[] { 9000, 4500, 560, 560 };
-        
+
         await _transmitter.TransmitRawAsync(pulses, 38000);
-        
+
         // Logger assertions removed - using NullLogger for simplicity
     }
 
@@ -122,7 +122,7 @@ public class MockInfraredTransmitterTests
     public void Dispose_ShouldLogDisposalMessage()
     {
         _transmitter.Dispose();
-        
+
         // Logger assertions removed - using NullLogger for simplicity
     }
 }

--- a/src/Zapper.Device.Infrared.Tests.Unit/ServiceCollectionExtensionsTests.cs
+++ b/src/Zapper.Device.Infrared.Tests.Unit/ServiceCollectionExtensionsTests.cs
@@ -12,7 +12,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -35,7 +35,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -45,7 +45,7 @@ public class ServiceCollectionExtensionsTests
             .Build();
 
         services.AddInfraredServices(configuration);
-        
+
         // We can't actually test real GPIO in a test environment,
         // but we can verify the service registration logic
         var serviceDescriptor = services.FirstOrDefault(s => s.ServiceType == typeof(IInfraredTransmitter));
@@ -58,7 +58,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -68,7 +68,7 @@ public class ServiceCollectionExtensionsTests
             .Build();
 
         services.AddInfraredServices(configuration);
-        
+
         // We can't actually test real GPIO in a test environment,
         // but we can verify the service registration is set up correctly
         var serviceDescriptor = services.FirstOrDefault(s => s.ServiceType == typeof(IInfraredTransmitter));
@@ -81,7 +81,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
 
         services.AddInfraredServices(configuration);
@@ -97,7 +97,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -119,7 +119,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {

--- a/src/Zapper.Device.Infrared/InfraredDeviceController.cs
+++ b/src/Zapper.Device.Infrared/InfraredDeviceController.cs
@@ -32,19 +32,19 @@ public class InfraredDeviceController : IDeviceController
         try
         {
             await _transmitter.TransmitAsync(command.IrCode, command.IsRepeatable ? 3 : 1);
-            
+
             if (command.DelayMs > 0)
             {
                 await Task.Delay(command.DelayMs);
             }
 
-            _logger.LogDebug("Successfully sent IR command {CommandName} to device {DeviceName}", 
+            _logger.LogDebug("Successfully sent IR command {CommandName} to device {DeviceName}",
                 command.Name, device.Name);
             return true;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send IR command {CommandName} to device {DeviceName}", 
+            _logger.LogError(ex, "Failed to send IR command {CommandName} to device {DeviceName}",
                 command.Name, device.Name);
             return false;
         }

--- a/src/Zapper.Device.Infrared/MockInfraredTransmitter.cs
+++ b/src/Zapper.Device.Infrared/MockInfraredTransmitter.cs
@@ -27,7 +27,7 @@ public class MockInfraredTransmitter : IInfraredTransmitter
             throw new InvalidOperationException("Mock IR transmitter not initialized");
 
         _logger.LogInformation("Mock transmitting IR code: {IrCode} (repeat {RepeatCount}x)", irCode, repeatCount);
-        
+
         await Task.Delay(100 * repeatCount, cancellationToken);
     }
 
@@ -36,9 +36,9 @@ public class MockInfraredTransmitter : IInfraredTransmitter
         if (!IsAvailable)
             throw new InvalidOperationException("Mock IR transmitter not initialized");
 
-        _logger.LogInformation("Mock transmitting IR code: {Brand} {Model} {Command} - {HexCode} (repeat {RepeatCount}x)", 
+        _logger.LogInformation("Mock transmitting IR code: {Brand} {Model} {Command} - {HexCode} (repeat {RepeatCount}x)",
                               irCode.Brand, irCode.Model, irCode.CommandName, irCode.HexCode, repeatCount);
-        
+
         await Task.Delay(100 * repeatCount, cancellationToken);
     }
 
@@ -47,9 +47,9 @@ public class MockInfraredTransmitter : IInfraredTransmitter
         if (!IsAvailable)
             throw new InvalidOperationException("Mock IR transmitter not initialized");
 
-        _logger.LogInformation("Mock transmitting raw IR signal: {PulseCount} pulses at {Frequency}Hz", 
+        _logger.LogInformation("Mock transmitting raw IR signal: {PulseCount} pulses at {Frequency}Hz",
                               pulses.Length, carrierFrequency);
-        
+
         var totalMicros = pulses.Sum();
         await Task.Delay(Math.Max(1, totalMicros / 10000), cancellationToken);
     }

--- a/src/Zapper.Device.Infrared/ServiceCollectionExtensions.cs
+++ b/src/Zapper.Device.Infrared/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ServiceCollectionExtensions
     {
         var useRealGpio = configuration.GetValue<bool>("Infrared:UseRealGpio", false);
         var gpioPin = configuration.GetValue<int>("Infrared:GpioPin", 18);
-        
+
         if (useRealGpio)
         {
             services.AddSingleton<IInfraredTransmitter>(provider =>
@@ -32,9 +32,9 @@ public static class ServiceCollectionExtensions
                 return transmitter;
             });
         }
-        
+
         services.AddSingleton<IDeviceController, InfraredDeviceController>();
-        
+
         return services;
     }
 }

--- a/src/Zapper.Device.Network/ServiceCollectionExtensions.cs
+++ b/src/Zapper.Device.Network/ServiceCollectionExtensions.cs
@@ -8,10 +8,10 @@ public static class ServiceCollectionExtensions
     {
         // Register HTTP client for network operations
         services.AddHttpClient<INetworkDeviceController, NetworkDeviceController>();
-        
+
         // Register the network device controller
         services.AddSingleton<INetworkDeviceController, NetworkDeviceController>();
-        
+
         return services;
     }
 }

--- a/src/Zapper.Device.Roku/RokuDeviceController.cs
+++ b/src/Zapper.Device.Roku/RokuDeviceController.cs
@@ -82,13 +82,13 @@ public class RokuDeviceController(INetworkDeviceController networkController, IL
         {
             var baseUrl = $"http://{ipAddress}:{RokuPort}";
             var success = await networkController.SendHttpCommandAsync(baseUrl, "/", "GET", null, null, cancellationToken);
-            
+
             if (success)
             {
                 logger.LogDebug("Successfully retrieved device info from Roku at {IpAddress}", ipAddress);
                 return "Roku Device"; // In a real implementation, we'd parse the XML response
             }
-            
+
             return null;
         }
         catch (Exception ex)
@@ -104,7 +104,7 @@ public class RokuDeviceController(INetworkDeviceController networkController, IL
         {
             var baseUrl = $"http://{ipAddress}:{RokuPort}";
             var endpoint = $"/launch/{appId}";
-            
+
             return await networkController.SendHttpCommandAsync(baseUrl, endpoint, "POST", null, null, cancellationToken);
         }
         catch (Exception ex)
@@ -120,7 +120,7 @@ public class RokuDeviceController(INetworkDeviceController networkController, IL
         {
             var baseUrl = $"http://{ipAddress}:{RokuPort}";
             var endpoint = $"/keypress/{keyCode}";
-            
+
             return await networkController.SendHttpCommandAsync(baseUrl, endpoint, "POST", null, null, cancellationToken);
         }
         catch (Exception ex)

--- a/src/Zapper.Device.Roku/RokuDiscovery.cs
+++ b/src/Zapper.Device.Roku/RokuDiscovery.cs
@@ -43,7 +43,7 @@ public class RokuDiscovery(ILogger<RokuDiscovery> logger, INetworkDeviceControll
         {
             var baseUrl = $"http://{ipAddress}:8060";
             var success = await networkController.SendHttpCommandAsync(baseUrl, "/", "GET", null, null, cancellationToken);
-            
+
             if (success)
             {
                 var device = new Zapper.Core.Models.Device
@@ -81,9 +81,9 @@ public class RokuDiscovery(ILogger<RokuDiscovery> logger, INetworkDeviceControll
             _udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 
             var multicastEndpoint = new IPEndPoint(IPAddress.Parse("239.255.255.250"), 1900);
-            
+
             // Send SSDP M-SEARCH request for Roku devices
-            var searchMessage = 
+            var searchMessage =
                 "M-SEARCH * HTTP/1.1\r\n" +
                 "HOST: 239.255.255.250:1900\r\n" +
                 "MX: 30\r\n" +
@@ -146,7 +146,7 @@ public class RokuDiscovery(ILogger<RokuDiscovery> logger, INetworkDeviceControll
             }
 
             var locationUrl = locationMatch.Groups[1].Value.Trim();
-            
+
             // Parse the IP address from the location URL
             var uri = new Uri(locationUrl);
             var ipAddress = uri.Host;
@@ -160,7 +160,7 @@ public class RokuDiscovery(ILogger<RokuDiscovery> logger, INetworkDeviceControll
                 {
                     var baseUrl = $"http://{ipAddress}:8060";
                     var success = await networkController.SendHttpCommandAsync(baseUrl, "/", "GET", null, null, cancellationToken);
-                    
+
                     if (success)
                     {
                         // In a real implementation, we'd parse the XML response to get device details

--- a/src/Zapper.Device.Roku/ServiceCollectionExtensions.cs
+++ b/src/Zapper.Device.Roku/ServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<IRokuDeviceController, RokuDeviceController>();
         services.AddSingleton<IRokuDiscovery, RokuDiscovery>();
-        
+
         return services;
     }
 }

--- a/src/Zapper.Device.USB.Tests.Unit/MockUsbRemoteHandlerTests.cs
+++ b/src/Zapper.Device.USB.Tests.Unit/MockUsbRemoteHandlerTests.cs
@@ -25,7 +25,7 @@ public class MockUsbRemoteHandlerTests
     public async Task StartListeningAsync_ShouldSetIsListeningToTrue()
     {
         await _handler.StartListeningAsync();
-        
+
         _handler.IsListening.Should().BeTrue();
     }
 
@@ -33,9 +33,9 @@ public class MockUsbRemoteHandlerTests
     public async Task StartListeningAsync_WhenAlreadyListening_ShouldNotThrow()
     {
         await _handler.StartListeningAsync();
-        
+
         var act = async () => await _handler.StartListeningAsync();
-        
+
         await act.Should().NotThrowAsync();
         _handler.IsListening.Should().BeTrue();
     }
@@ -45,7 +45,7 @@ public class MockUsbRemoteHandlerTests
     {
         await _handler.StartListeningAsync();
         await _handler.StopListeningAsync();
-        
+
         _handler.IsListening.Should().BeFalse();
     }
 
@@ -53,7 +53,7 @@ public class MockUsbRemoteHandlerTests
     public async Task StopListeningAsync_WhenNotListening_ShouldNotThrow()
     {
         var act = async () => await _handler.StopListeningAsync();
-        
+
         await act.Should().NotThrowAsync();
     }
 
@@ -61,7 +61,7 @@ public class MockUsbRemoteHandlerTests
     public void GetConnectedRemotes_ShouldReturnMockDevices()
     {
         var remotes = _handler.GetConnectedRemotes();
-        
+
         remotes.Should().NotBeEmpty();
         remotes.Should().Contain("MOCK:0001:remote1");
         remotes.Should().Contain("MOCK:0002:remote2");
@@ -71,12 +71,12 @@ public class MockUsbRemoteHandlerTests
     public async Task SimulateButtonPress_WhenListening_ShouldRaiseButtonPressedEvent()
     {
         await _handler.StartListeningAsync();
-        
+
         RemoteButtonEventArgs? capturedArgs = null;
         _handler.ButtonPressed += (sender, args) => capturedArgs = args;
-        
+
         _handler.SimulateButtonPress("TEST:001", "Power", 0x01);
-        
+
         capturedArgs.Should().NotBeNull();
         capturedArgs!.DeviceId.Should().Be("TEST:001");
         capturedArgs.ButtonName.Should().Be("Power");
@@ -89,9 +89,9 @@ public class MockUsbRemoteHandlerTests
     {
         var eventRaised = false;
         _handler.ButtonPressed += (sender, args) => eventRaised = true;
-        
+
         _handler.SimulateButtonPress("TEST:001", "Power", 0x01);
-        
+
         eventRaised.Should().BeFalse();
     }
 
@@ -99,14 +99,14 @@ public class MockUsbRemoteHandlerTests
     public async Task ButtonPressedEvent_ShouldContainCorrectTimestamp()
     {
         await _handler.StartListeningAsync();
-        
+
         var before = DateTime.UtcNow;
         RemoteButtonEventArgs? capturedArgs = null;
         _handler.ButtonPressed += (sender, args) => capturedArgs = args;
-        
+
         _handler.SimulateButtonPress("TEST:001", "VolumeUp", 0x02);
         var after = DateTime.UtcNow;
-        
+
         capturedArgs.Should().NotBeNull();
         capturedArgs!.Timestamp.Should().BeAfter(before).And.BeBefore(after);
     }
@@ -115,15 +115,15 @@ public class MockUsbRemoteHandlerTests
     public async Task MultipleEventSubscribers_ShouldAllReceiveEvents()
     {
         await _handler.StartListeningAsync();
-        
+
         var subscriber1Called = false;
         var subscriber2Called = false;
-        
+
         _handler.ButtonPressed += (sender, args) => subscriber1Called = true;
         _handler.ButtonPressed += (sender, args) => subscriber2Called = true;
-        
+
         _handler.SimulateButtonPress("TEST:001", "Menu", 0x0C);
-        
+
         subscriber1Called.Should().BeTrue();
         subscriber2Called.Should().BeTrue();
     }
@@ -132,15 +132,15 @@ public class MockUsbRemoteHandlerTests
     public async Task EventUnsubscription_ShouldPreventEventDelivery()
     {
         await _handler.StartListeningAsync();
-        
+
         var eventReceived = false;
         EventHandler<RemoteButtonEventArgs> handler = (sender, args) => eventReceived = true;
-        
+
         _handler.ButtonPressed += handler;
         _handler.ButtonPressed -= handler;
-        
+
         _handler.SimulateButtonPress("TEST:001", "Back", 0x0D);
-        
+
         eventReceived.Should().BeFalse();
     }
 }

--- a/src/Zapper.Device.USB.Tests.Unit/ServiceCollectionExtensionsTests.cs
+++ b/src/Zapper.Device.USB.Tests.Unit/ServiceCollectionExtensionsTests.cs
@@ -13,7 +13,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -38,7 +38,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -61,7 +61,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
 
         services.AddUsbServices(configuration);
@@ -77,7 +77,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -99,7 +99,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -121,7 +121,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -143,14 +143,14 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
 
         services.AddUsbServices(configuration);
 
         // Verify all expected service registrations exist
         var serviceDescriptors = services.ToList();
-        
+
         serviceDescriptors.Should().Contain(s => s.ServiceType == typeof(IUsbRemoteHandler));
         serviceDescriptors.Should().Contain(s => s.ServiceType == typeof(IDeviceController));
         serviceDescriptors.Should().Contain(s => s.ServiceType == typeof(IHostedService));
@@ -164,7 +164,7 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        
+
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {

--- a/src/Zapper.Device.USB.Tests.Unit/UsbRemoteHandlerTests.cs
+++ b/src/Zapper.Device.USB.Tests.Unit/UsbRemoteHandlerTests.cs
@@ -27,7 +27,7 @@ public class UsbRemoteHandlerTests
         // Since we can't actually test real HID devices in unit tests,
         // we'll test the basic state management
         var act = async () => await _handler.StartListeningAsync();
-        
+
         await act.Should().NotThrowAsync();
     }
 
@@ -35,7 +35,7 @@ public class UsbRemoteHandlerTests
     public async Task StopListeningAsync_WhenNotListening_ShouldNotThrow()
     {
         var act = async () => await _handler.StopListeningAsync();
-        
+
         await act.Should().NotThrowAsync();
     }
 
@@ -43,7 +43,7 @@ public class UsbRemoteHandlerTests
     public void GetConnectedRemotes_WhenNoDevices_ShouldReturnEmpty()
     {
         var remotes = _handler.GetConnectedRemotes();
-        
+
         // Without real HID devices, this should return empty
         remotes.Should().NotBeNull();
     }
@@ -52,7 +52,7 @@ public class UsbRemoteHandlerTests
     public void Dispose_ShouldNotThrow()
     {
         var act = () => _handler.Dispose();
-        
+
         act.Should().NotThrow();
     }
 
@@ -64,7 +64,7 @@ public class UsbRemoteHandlerTests
             _handler.Dispose();
             _handler.Dispose();
         };
-        
+
         act.Should().NotThrow();
     }
 
@@ -74,7 +74,7 @@ public class UsbRemoteHandlerTests
         // Test basic lifecycle without real devices
         await _handler.StartListeningAsync();
         await _handler.StopListeningAsync();
-        
+
         // Should be able to start again
         await _handler.StartListeningAsync();
         _handler.Dispose();
@@ -92,11 +92,11 @@ public class UsbRemoteHandlerTests
     public void MapKeyCodeToButton_ShouldReturnCorrectButtonName(byte keyCode, string expectedButton)
     {
         // Use reflection to test the private method
-        var method = typeof(UsbRemoteHandler).GetMethod("MapKeyCodeToButton", 
+        var method = typeof(UsbRemoteHandler).GetMethod("MapKeyCodeToButton",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         var result = (string)method!.Invoke(_handler, [keyCode])!;
-        
+
         result.Should().Be(expectedButton);
     }
 
@@ -106,10 +106,10 @@ public class UsbRemoteHandlerTests
         // Since we can't easily mock HidDevice, we'll test the concept
         // In a real scenario, you would mock the HidDevice interface
         // For now, we'll test that the method exists and doesn't throw during reflection
-        
-        var method = typeof(UsbRemoteHandler).GetMethod("GetDeviceId", 
+
+        var method = typeof(UsbRemoteHandler).GetMethod("GetDeviceId",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         method.Should().NotBeNull();
     }
 
@@ -117,9 +117,9 @@ public class UsbRemoteHandlerTests
     public void IsRemoteDevice_Method_ShouldExist()
     {
         // Test that the private method exists for device filtering
-        var method = typeof(UsbRemoteHandler).GetMethod("IsRemoteDevice", 
+        var method = typeof(UsbRemoteHandler).GetMethod("IsRemoteDevice",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
+
         method.Should().NotBeNull();
     }
 
@@ -128,10 +128,10 @@ public class UsbRemoteHandlerTests
     {
         // Start first (though it may not actually start without real devices)
         await _handler.StartListeningAsync();
-        
+
         // Stop should always work
         await _handler.StopListeningAsync();
-        
+
         // After stopping, IsListening should be false
         _handler.IsListening.Should().BeFalse();
     }

--- a/src/Zapper.Device.USB/ServiceCollectionExtensions.cs
+++ b/src/Zapper.Device.USB/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddUsbServices(this IServiceCollection services, IConfiguration configuration)
     {
         var useMockHandler = configuration.GetValue<bool>("USB:UseMockHandler", true);
-        
+
         if (useMockHandler)
         {
             services.AddSingleton<IUsbRemoteHandler>(provider =>
@@ -28,13 +28,13 @@ public static class ServiceCollectionExtensions
                 return new UsbRemoteHandler(logger);
             });
         }
-        
+
         // Register the device controller
         services.AddSingleton<IDeviceController, UsbDeviceController>();
-        
+
         // Register as hosted service to manage lifecycle
         services.AddSingleton<IHostedService, UsbRemoteHostedService>();
-        
+
         return services;
     }
 }

--- a/src/Zapper.Device.USB/UsbDeviceController.cs
+++ b/src/Zapper.Device.USB/UsbDeviceController.cs
@@ -14,9 +14,9 @@ public class UsbDeviceController(IUsbRemoteHandler remoteHandler, ILogger<UsbDev
             return false;
         }
 
-        logger.LogWarning("USB devices are input-only. Cannot send command {CommandName} to device {DeviceName}", 
+        logger.LogWarning("USB devices are input-only. Cannot send command {CommandName} to device {DeviceName}",
             command.Name, device.Name);
-        
+
         return await Task.FromResult(false);
     }
 
@@ -26,11 +26,11 @@ public class UsbDeviceController(IUsbRemoteHandler remoteHandler, ILogger<UsbDev
             return Task.FromResult(false);
 
         var connectedRemotes = remoteHandler.GetConnectedRemotes();
-        var isConnected = connectedRemotes.Any(remote => 
-            remote.Contains(device.MacAddress ?? "") || 
+        var isConnected = connectedRemotes.Any(remote =>
+            remote.Contains(device.MacAddress ?? "") ||
             remote.Contains(device.Name));
 
-        logger.LogDebug("USB device {DeviceName} connection test: {IsConnected}", 
+        logger.LogDebug("USB device {DeviceName} connection test: {IsConnected}",
             device.Name, isConnected);
 
         return Task.FromResult(isConnected);
@@ -48,15 +48,15 @@ public class UsbDeviceController(IUsbRemoteHandler remoteHandler, ILogger<UsbDev
         }
 
         var connectedRemotes = remoteHandler.GetConnectedRemotes();
-        var isConnected = connectedRemotes.Any(remote => 
-            remote.Contains(device.MacAddress ?? "") || 
+        var isConnected = connectedRemotes.Any(remote =>
+            remote.Contains(device.MacAddress ?? "") ||
             remote.Contains(device.Name));
 
         var status = new DeviceStatus
         {
             IsOnline = isConnected,
-            StatusMessage = isConnected 
-                ? $"USB remote connected via {device.MacAddress}" 
+            StatusMessage = isConnected
+                ? $"USB remote connected via {device.MacAddress}"
                 : "USB remote not found"
         };
 

--- a/src/Zapper.Device.USB/UsbRemoteHostedService.cs
+++ b/src/Zapper.Device.USB/UsbRemoteHostedService.cs
@@ -8,14 +8,14 @@ public class UsbRemoteHostedService(IUsbRemoteHandler remoteHandler, ILogger<Usb
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         logger.LogInformation("Starting USB remote service");
-        
+
         try
         {
             await remoteHandler.StartListeningAsync(cancellationToken);
-            
+
             // Subscribe to button events for logging
             remoteHandler.ButtonPressed += OnButtonPressed;
-            
+
             logger.LogInformation("USB remote service started successfully");
         }
         catch (Exception ex)
@@ -28,12 +28,12 @@ public class UsbRemoteHostedService(IUsbRemoteHandler remoteHandler, ILogger<Usb
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         logger.LogInformation("Stopping USB remote service");
-        
+
         try
         {
             remoteHandler.ButtonPressed -= OnButtonPressed;
             await remoteHandler.StopListeningAsync();
-            
+
             logger.LogInformation("USB remote service stopped");
         }
         catch (Exception ex)
@@ -44,7 +44,7 @@ public class UsbRemoteHostedService(IUsbRemoteHandler remoteHandler, ILogger<Usb
 
     private void OnButtonPressed(object? sender, RemoteButtonEventArgs e)
     {
-        logger.LogInformation("USB remote button pressed: Device={DeviceId}, Button={ButtonName}, KeyCode=0x{KeyCode:X2}", 
+        logger.LogInformation("USB remote button pressed: Device={DeviceId}, Button={ButtonName}, KeyCode=0x{KeyCode:X2}",
             e.DeviceId, e.ButtonName, e.KeyCode);
     }
 }

--- a/src/Zapper.Device.WebOS/WebOSClient.cs
+++ b/src/Zapper.Device.WebOS/WebOSClient.cs
@@ -112,11 +112,11 @@ public class WebOsClient(ILogger<WebOsClient> logger) : IWebOsClient, IDisposabl
             };
 
             var response = await SendCommandAsync("ssap://com.webos.service.pairing/register", authPayload, cancellationToken);
-            
+
             if (response != null)
             {
                 var responseObj = JsonSerializer.Deserialize<JsonElement>(response);
-                if (responseObj.TryGetProperty("payload", out var payload) && 
+                if (responseObj.TryGetProperty("payload", out var payload) &&
                     payload.TryGetProperty("client-key", out var clientKeyElement))
                 {
                     _clientKey = clientKeyElement.GetString();
@@ -193,7 +193,7 @@ public class WebOsClient(ILogger<WebOsClient> logger) : IWebOsClient, IDisposabl
             while (_webSocket?.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
             {
                 var result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
-                
+
                 if (result.MessageType == WebSocketMessageType.Text)
                 {
                     var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
@@ -215,7 +215,7 @@ public class WebOsClient(ILogger<WebOsClient> logger) : IWebOsClient, IDisposabl
         try
         {
             var messageObj = JsonSerializer.Deserialize<JsonElement>(message);
-            
+
             if (messageObj.TryGetProperty("id", out var idElement))
             {
                 var id = idElement.GetString();

--- a/src/Zapper.Device.WebOS/WebOSDiscovery.cs
+++ b/src/Zapper.Device.WebOS/WebOSDiscovery.cs
@@ -30,7 +30,7 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
 
             // Start SSDP discovery
             var ssdpTask = PerformSsdpDiscoveryAsync(timeout, timeoutCts.Token);
-            
+
             // Start mDNS discovery
             var mdnsTask = PerformMdnsDiscoveryAsync(timeout, timeoutCts.Token);
 
@@ -147,9 +147,9 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
             _udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 
             var multicastEndpoint = new IPEndPoint(IPAddress.Parse("239.255.255.250"), 1900);
-            
+
             // Send SSDP M-SEARCH request for WebOS devices
-            var searchMessage = 
+            var searchMessage =
                 "M-SEARCH * HTTP/1.1\r\n" +
                 "HOST: 239.255.255.250:1900\r\n" +
                 "MX: 30\r\n" +
@@ -202,7 +202,7 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
 
             // Simple mDNS-style discovery by checking common hostnames
             var commonHostnames = new[] { "lgsmarttv.local", "webostv.local" };
-            
+
             foreach (var hostname in commonHostnames)
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -259,7 +259,7 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
         {
             // Get local IP addresses
             var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces()
-                .Where(ni => ni.OperationalStatus == OperationalStatus.Up && 
+                .Where(ni => ni.OperationalStatus == OperationalStatus.Up &&
                            ni.NetworkInterfaceType != NetworkInterfaceType.Loopback);
 
             foreach (var networkInterface in networkInterfaces)
@@ -293,7 +293,7 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
         {
             var network = GetNetworkAddress(localIp, subnetMask);
             var broadcastAddress = GetBroadcastAddress(localIp, subnetMask);
-            
+
             // Limit scanning based on available timeout
             var maxAddresses = Math.Min(20, (int)(timeout.TotalSeconds / 2)); // 2 seconds per address estimate
             if (maxAddresses < 1) maxAddresses = 1;
@@ -307,7 +307,7 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
                     break;
 
                 tasks.Add(CheckAddressForWebOsAsync(address, cancellationToken));
-                
+
                 // Limit concurrent scans to avoid overwhelming the network
                 if (tasks.Count >= 3)
                 {
@@ -331,7 +331,7 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
             using var ping = new Ping();
             // Use a much shorter ping timeout for subnet scanning
             var reply = await ping.SendPingAsync(address, 200);
-            
+
             if (reply.Status == IPStatus.Success)
             {
                 // Only try WebOS discovery if ping succeeds and we haven't been cancelled
@@ -356,7 +356,7 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
         try
         {
             var response = Encoding.UTF8.GetString(responseBytes);
-            
+
             // Check if this is a WebOS device response
             if (response.Contains("urn:lge-com:service:webos-second-screen") ||
                 response.Contains("LG Electronics"))
@@ -438,7 +438,7 @@ public class WebOsDiscovery(ILogger<WebOsDiscovery> logger, IWebOsClient webOsCl
     {
         var networkBytes = network.GetAddressBytes();
         var broadcastBytes = broadcast.GetAddressBytes();
-        
+
         var count = 0;
         for (int i = networkBytes[3] + 1; i < broadcastBytes[3] && count < maxAddresses; i++)
         {

--- a/src/Zapper.Device.WebOS/WebOSHardwareController.cs
+++ b/src/Zapper.Device.WebOS/WebOSHardwareController.cs
@@ -58,7 +58,7 @@ public class WebOsHardwareController(IWebOsClient webOsClient, ILogger<WebOsHard
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to send WebOS command {CommandType} to device {DeviceName}", 
+            logger.LogError(ex, "Failed to send WebOS command {CommandType} to device {DeviceName}",
                 command.Type, device.Name);
             return false;
         }
@@ -99,7 +99,7 @@ public class WebOsHardwareController(IWebOsClient webOsClient, ILogger<WebOsHard
         if (!string.IsNullOrEmpty(command.HttpEndpoint))
         {
             // For custom commands, use the HttpEndpoint field as the SSAP URI
-            var response = await webOsClient.SendCommandAsync(command.HttpEndpoint, 
+            var response = await webOsClient.SendCommandAsync(command.HttpEndpoint,
                 string.IsNullOrEmpty(command.NetworkPayload) ? null : command.NetworkPayload, cancellationToken);
             return response != null;
         }
@@ -110,24 +110,24 @@ public class WebOsHardwareController(IWebOsClient webOsClient, ILogger<WebOsHard
     private async Task<bool> HandleUnknownCommand(DeviceCommand command, CancellationToken cancellationToken)
     {
         logger.LogWarning("Unknown WebOS command type: {CommandType}", command.Type);
-        
+
         // Try to execute as a direct SSAP URI if HttpEndpoint field is set
         if (!string.IsNullOrEmpty(command.HttpEndpoint))
         {
-            var response = await webOsClient.SendCommandAsync(command.HttpEndpoint, 
+            var response = await webOsClient.SendCommandAsync(command.HttpEndpoint,
                 string.IsNullOrEmpty(command.NetworkPayload) ? null : command.NetworkPayload, cancellationToken);
             return response != null;
         }
-        
+
         return false;
     }
 
     public Task<bool> TestConnectionAsync(Zapper.Core.Models.Device device, CancellationToken cancellationToken = default)
     {
         // For WebOS devices, testing connection means trying to connect and authenticate
-        return SendCommandAsync(device, new DeviceCommand 
-        { 
-            Type = CommandType.Custom, 
+        return SendCommandAsync(device, new DeviceCommand
+        {
+            Type = CommandType.Custom,
             NetworkPayload = "Connection test from ZapperHub",
             HttpEndpoint = "ssap://system.notifications/createToast"
         }, cancellationToken);

--- a/src/Zapper.Device.WebOS/WebOSProtocolController.cs
+++ b/src/Zapper.Device.WebOS/WebOSProtocolController.cs
@@ -18,19 +18,19 @@ public class WebOsProtocolController(IWebOsDeviceController webOsController, ILo
         try
         {
             var result = await webOsController.SendCommandAsync(device, command);
-            
+
             if (command.DelayMs > 0)
             {
                 await Task.Delay(command.DelayMs);
             }
 
-            logger.LogDebug("Successfully sent WebOS command {CommandName} to device {DeviceName}", 
+            logger.LogDebug("Successfully sent WebOS command {CommandName} to device {DeviceName}",
                 command.Name, device.Name);
             return result;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to send WebOS command {CommandName} to device {DeviceName}", 
+            logger.LogError(ex, "Failed to send WebOS command {CommandName} to device {DeviceName}",
                 command.Name, device.Name);
             return false;
         }

--- a/src/Zapper.Host/Program.cs
+++ b/src/Zapper.Host/Program.cs
@@ -23,13 +23,13 @@ builder.Services.AddSingleton<IInfraredTransmitter>(provider =>
 {
     var logger = provider.GetRequiredService<ILogger<GpioInfraredTransmitter>>();
     var config = provider.GetRequiredService<IConfiguration>();
-    
+
     // Use mock transmitter if GPIO is disabled
     if (!config.GetValue<bool>("Hardware:EnableGPIO", true))
     {
         return new MockInfraredTransmitter(provider.GetRequiredService<ILogger<MockInfraredTransmitter>>());
     }
-    
+
     var gpioPin = config.GetValue<int>("Hardware:IRTransmitter:GpioPin", 18);
     return new GpioInfraredTransmitter(gpioPin, logger);
 });

--- a/src/Zapper.Services/ActivityService.cs
+++ b/src/Zapper.Services/ActivityService.cs
@@ -94,7 +94,7 @@ public class ActivityService(
         }
 
         logger.LogInformation("Executing activity: {ActivityName}", activity.Name);
-        
+
         await notificationService.NotifyActivityStartedAsync(activity.Id, activity.Name);
 
         try
@@ -113,32 +113,32 @@ public class ActivityService(
                 }
 
                 var success = await deviceService.SendCommandAsync(
-                    step.DeviceCommand.DeviceId, 
-                    step.DeviceCommand.Name, 
+                    step.DeviceCommand.DeviceId,
+                    step.DeviceCommand.Name,
                     cancellationToken);
 
                 await notificationService.NotifyActivityStepExecutedAsync(
-                    activity.Id, activity.Name, step.StepOrder, 
+                    activity.Id, activity.Name, step.StepOrder,
                     $"{step.DeviceCommand.Device.Name} - {step.DeviceCommand.Name}", success);
 
                 if (!success && step.IsRequired)
                 {
-                    logger.LogError("Required step failed in activity {ActivityName}: {DeviceName} - {CommandName}", 
+                    logger.LogError("Required step failed in activity {ActivityName}: {DeviceName} - {CommandName}",
                                    activity.Name, step.DeviceCommand.Device.Name, step.DeviceCommand.Name);
-                    
+
                     await notificationService.NotifyActivityCompletedAsync(activity.Id, activity.Name, false);
                     return false;
                 }
 
                 if (!success)
                 {
-                    logger.LogWarning("Optional step failed in activity {ActivityName}: {DeviceName} - {CommandName}", 
+                    logger.LogWarning("Optional step failed in activity {ActivityName}: {DeviceName} - {CommandName}",
                                      activity.Name, step.DeviceCommand.Device.Name, step.DeviceCommand.Name);
                 }
                 else
                 {
                     executedSteps++;
-                    logger.LogDebug("Executed step {StepOrder}: {DeviceName} - {CommandName}", 
+                    logger.LogDebug("Executed step {StepOrder}: {DeviceName} - {CommandName}",
                                    step.StepOrder, step.DeviceCommand.Device.Name, step.DeviceCommand.Name);
                 }
 
@@ -152,9 +152,9 @@ public class ActivityService(
             activity.LastUsed = DateTime.UtcNow;
             await context.SaveChangesAsync();
 
-            logger.LogInformation("Activity {ActivityName} completed successfully. Executed {ExecutedSteps}/{TotalSteps} steps", 
+            logger.LogInformation("Activity {ActivityName} completed successfully. Executed {ExecutedSteps}/{TotalSteps} steps",
                                  activity.Name, executedSteps, steps.Count);
-            
+
             await notificationService.NotifyActivityCompletedAsync(activity.Id, activity.Name, true);
             return true;
         }
@@ -248,7 +248,7 @@ public class ActivityService(
         context.ActivitySteps.Add(step);
         await context.SaveChangesAsync();
 
-        logger.LogInformation("Added step to activity {ActivityName}: {StepOrder} - {CommandName}", 
+        logger.LogInformation("Added step to activity {ActivityName}: {StepOrder} - {CommandName}",
                              activity.Name, stepOrder, deviceCommand.Name);
         return step;
     }

--- a/src/Zapper.Services/DeviceService.cs
+++ b/src/Zapper.Services/DeviceService.cs
@@ -108,13 +108,13 @@ public class DeviceService(
         try
         {
             var success = await ExecuteCommandAsync(device, command, cancellationToken);
-            
+
             if (success)
             {
                 device.LastSeen = DateTime.UtcNow;
                 device.IsOnline = true;
                 await context.SaveChangesAsync();
-                
+
                 await notificationService.NotifyDeviceCommandExecutedAsync(device.Id, device.Name, commandName, true);
             }
             else
@@ -143,11 +143,11 @@ public class DeviceService(
         {
             bool isOnline = device.ConnectionType switch
             {
-                ConnectionType.NetworkTcp or ConnectionType.NetworkWebSocket => 
+                ConnectionType.NetworkTcp or ConnectionType.NetworkWebSocket =>
                     await TestNetworkDeviceAsync(device),
                 ConnectionType.NetworkHttp =>
                     await rokuController.TestConnectionAsync(device),
-                ConnectionType.InfraredIr => 
+                ConnectionType.InfraredIr =>
                     irTransmitter.IsAvailable,
                 ConnectionType.WebOs =>
                     await webOsController.TestConnectionAsync(device),
@@ -157,7 +157,7 @@ public class DeviceService(
             device.IsOnline = isOnline;
             device.LastSeen = DateTime.UtcNow;
             await context.SaveChangesAsync();
-            
+
             await notificationService.NotifyDeviceStatusChangedAsync(device.Id, device.Name, isOnline);
 
             return isOnline;
@@ -174,12 +174,12 @@ public class DeviceService(
         try
         {
             var discoveryResult = await networkController.DiscoverDevicesAsync(deviceType, TimeSpan.FromSeconds(10), cancellationToken);
-            
+
             if (string.IsNullOrEmpty(discoveryResult))
                 return [];
 
             var devices = new List<Zapper.Core.Models.Device>();
-            
+
             logger.LogInformation("Device discovery completed for type: {DeviceType}", deviceType);
             return devices;
         }
@@ -214,7 +214,7 @@ public class DeviceService(
         }
 
         await irTransmitter.TransmitAsync(command.IrCode, command.IsRepeatable ? 3 : 1, cancellationToken);
-        
+
         if (command.DelayMs > 0)
         {
             await Task.Delay(command.DelayMs, cancellationToken);
@@ -232,10 +232,10 @@ public class DeviceService(
         }
 
         return await networkController.SendCommandAsync(
-            device.IpAddress, 
-            device.Port.Value, 
-            command.Name, 
-            command.NetworkPayload, 
+            device.IpAddress,
+            device.Port.Value,
+            command.Name,
+            command.NetworkPayload,
             cancellationToken);
     }
 

--- a/src/Zapper.Services/IRCodeService.cs
+++ b/src/Zapper.Services/IRCodeService.cs
@@ -54,8 +54,8 @@ public class IrCodeService(ZapperContext context, ILogger<IrCodeService> logger)
     {
         return await context.IrCodeSets
             .Include(cs => cs.Codes)
-            .FirstOrDefaultAsync(cs => cs.Brand.ToLower() == brand.ToLower() 
-                                    && cs.Model.ToLower() == model.ToLower() 
+            .FirstOrDefaultAsync(cs => cs.Brand.ToLower() == brand.ToLower()
+                                    && cs.Model.ToLower() == model.ToLower()
                                     && cs.DeviceType == deviceType);
     }
 
@@ -70,7 +70,7 @@ public class IrCodeService(ZapperContext context, ILogger<IrCodeService> logger)
     public async Task<IrCode?> GetCodeAsync(int codeSetId, string commandName)
     {
         return await context.IrCodes
-            .FirstOrDefaultAsync(c => EF.Property<int>(c, "IRCodeSetId") == codeSetId 
+            .FirstOrDefaultAsync(c => EF.Property<int>(c, "IRCodeSetId") == codeSetId
                                    && c.CommandName.ToLower() == commandName.ToLower());
     }
 
@@ -90,7 +90,7 @@ public class IrCodeService(ZapperContext context, ILogger<IrCodeService> logger)
         }
 
         context.Entry(code).Property("IRCodeSetId").CurrentValue = codeSetId;
-        
+
         context.IrCodes.Add(code);
         await context.SaveChangesAsync();
         return code;
@@ -119,7 +119,7 @@ public class IrCodeService(ZapperContext context, ILogger<IrCodeService> logger)
         {
             var json = await File.ReadAllTextAsync(filePath);
             var importData = JsonSerializer.Deserialize<IrCodeSetImport>(json);
-            
+
             if (importData == null) return false;
 
             var codeSet = new IrCodeSet
@@ -197,7 +197,7 @@ public class IrCodeService(ZapperContext context, ILogger<IrCodeService> logger)
         logger.LogInformation("Seeding default IR codes...");
 
         var defaultCodeSets = GetDefaultCodeSets();
-        
+
         foreach (var codeSet in defaultCodeSets)
         {
             await CreateCodeSetAsync(codeSet);

--- a/src/Zapper.Services/NotificationService.cs
+++ b/src/Zapper.Services/NotificationService.cs
@@ -18,8 +18,8 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
 
         await SendToDeviceGroupAsync(deviceId, "DeviceStatusChanged", data);
         await SendToAllClientsAsync("DeviceStatusChanged", data);
-        
-        logger.LogInformation("Device status changed: {DeviceName} is now {Status}", 
+
+        logger.LogInformation("Device status changed: {DeviceName} is now {Status}",
             deviceName, isOnline ? "online" : "offline");
     }
 
@@ -35,8 +35,8 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
         };
 
         await SendToDeviceGroupAsync(deviceId, "DeviceCommandExecuted", data);
-        
-        logger.LogInformation("Device command executed: {DeviceName} - {CommandName} ({Status})", 
+
+        logger.LogInformation("Device command executed: {DeviceName} - {CommandName} ({Status})",
             deviceName, commandName, success ? "success" : "failed");
     }
 
@@ -52,7 +52,7 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
 
         await SendToActivityGroupAsync(activityId, "ActivityStatusChanged", data);
         await SendToAllClientsAsync("ActivityStatusChanged", data);
-        
+
         logger.LogInformation("Activity started: {ActivityName}", activityName);
     }
 
@@ -69,8 +69,8 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
 
         await SendToActivityGroupAsync(activityId, "ActivityStatusChanged", data);
         await SendToAllClientsAsync("ActivityStatusChanged", data);
-        
-        logger.LogInformation("Activity completed: {ActivityName} ({Status})", 
+
+        logger.LogInformation("Activity completed: {ActivityName} ({Status})",
             activityName, success ? "success" : "failed");
     }
 
@@ -87,8 +87,8 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
         };
 
         await SendToActivityGroupAsync(activityId, "ActivityStepExecuted", data);
-        
-        logger.LogInformation("Activity step executed: {ActivityName} - Step {StepNumber} ({Status})", 
+
+        logger.LogInformation("Activity step executed: {ActivityName} - Step {StepNumber} ({Status})",
             activityName, stepNumber, success ? "success" : "failed");
     }
 
@@ -103,8 +103,8 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
         };
 
         await SendToAllClientsAsync("DeviceDiscovered", data);
-        
-        logger.LogInformation("Device discovered: {DeviceName} ({DeviceType}) at {DeviceAddress}", 
+
+        logger.LogInformation("Device discovered: {DeviceName} ({DeviceType}) at {DeviceAddress}",
             deviceName, deviceType, deviceAddress);
     }
 
@@ -119,7 +119,7 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
         };
 
         await SendToAllClientsAsync("BluetoothDeviceStatusChanged", data);
-        
+
         logger.LogInformation("Bluetooth device connected: {DeviceName}", deviceName);
     }
 
@@ -134,7 +134,7 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
         };
 
         await SendToAllClientsAsync("BluetoothDeviceStatusChanged", data);
-        
+
         logger.LogInformation("Bluetooth device disconnected: {DeviceName}", deviceName);
     }
 
@@ -150,8 +150,8 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
         };
 
         await SendToAllClientsAsync("WebOSDevicePaired", data);
-        
-        logger.LogInformation("WebOS device pairing: {DeviceName} ({Status})", 
+
+        logger.LogInformation("WebOS device pairing: {DeviceName} ({Status})",
             deviceName, success ? "success" : "failed");
     }
 
@@ -165,7 +165,7 @@ public class NotificationService(IHubContext<ZapperSignalR> hubContext, ILogger<
         };
 
         await SendToAllClientsAsync("SystemMessage", data);
-        
+
         logger.LogInformation("System message sent: {Message} (level: {Level})", message, level);
     }
 


### PR DESCRIPTION
## Summary
This PR enables treating warnings as errors across all projects in the solution to maintain code quality.

## Changes
- Created `Directory.Build.props` at the src level to apply build settings globally
- Enabled `TreatWarningsAsErrors` for all projects
- Added additional build improvements:
  - Enabled nullable reference types
  - Set language version to latest
  - Enabled implicit usings
  - Generate documentation files
  - Suppressed CS1591 warning (missing XML comments) temporarily

## Testing
- ✅ Build succeeds with no warnings
- ✅ All unit tests pass (205 tests total)
  - Zapper.Device.Roku.Tests.Unit: 3 tests
  - Zapper.Device.Infrared.Tests.Unit: 47 tests  
  - Zapper.Device.Bluetooth.Tests.Unit: 44 tests
  - Zapper.Device.Network.Tests.Unit: 10 tests
  - Zapper.Device.USB.Tests.Unit: 75 tests
  - Zapper.Device.WebOS.Tests.Unit: 26 tests

## Closes
Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)