### PR TITLE
fix: Handle DBusException in Bluetooth test for CI

### DIFF
--- a/src/Zapper.Device.Bluetooth.Tests.Unit/BluetoothServiceTests.cs
+++ b/src/Zapper.Device.Bluetooth.Tests.Unit/BluetoothServiceTests.cs
@@ -59,9 +59,11 @@ public class BluetoothServiceTests
                 Arg.Any<Exception>(),
                 Arg.Any<Func<object, Exception?, string>>());
         }
-        catch (InvalidOperationException)
+        catch (Exception ex) when (ex.GetType().Name == "DBusException" || ex is InvalidOperationException)
         {
             // Expected when BlueZ is not available in test environment
+            // DBusException: org.freedesktop.DBus.Error.ServiceUnknown occurs in CI
+            // InvalidOperationException: No Bluetooth adapters found occurs locally
             // This is acceptable for unit tests
         }
     }


### PR DESCRIPTION
## Summary
This PR fixes a failing test in the CI environment where BlueZ service is not available.

## Problem
The test `InitializeAsync_WhenCalledMultipleTimes_ShouldNotReinitialize` was failing in GitHub Actions with:
```
DBusException : org.freedesktop.DBus.Error.ServiceUnknown: The name org.bluez was not provided by any .service files
```

## Solution
Updated the exception handling in the test to catch both:
- `DBusException` - thrown in CI when BlueZ service is not available
- `InvalidOperationException` - thrown locally when no Bluetooth adapters are found

## Testing
- ✅ Test now passes locally
- ✅ All 44 Bluetooth tests pass
- The fix will be validated by the CI pipeline on this PR

This is a test-only change that makes the test more robust across different environments.